### PR TITLE
Fixed font size

### DIFF
--- a/progs/convert/html/tmhtml.scm
+++ b/progs/convert/html/tmhtml.scm
@@ -957,8 +957,8 @@
          ;; Generate font-size style string
          (font-size-style (string-append "font-size: " (number->string computed-size) "%;"))
         )
-    (display "Computed font size percentage: ") (display computed-size) (display "%") (newline)
-    (display "Generated font-size style: ") (display font-size-style) (newline)
+    ; (display "Computed font size percentage: ") (display computed-size) (display "%") (newline)
+    ; (display "Generated font-size style: ") (display font-size-style) (newline)
     ;; Recursively process arg and apply the style
     `((h:span (@ (style ,font-size-style)) ,@(tmhtml arg)))))
 
@@ -1002,7 +1002,7 @@
            (list (append w (tmhtml arg)))))
         ((logic-ref tmhtml-with-cmd% (list var)) =>
          (lambda (x)
-           (display (string-append "tmhtml-with-one: match var = " var "\n"))
+          ;  (display (string-append "tmhtml-with-one: match var = " var "\n"))
            (ahash-with tmhtml-env x val (tmhtml arg))))
         ((logic-ref tmhtml-with-cmd% var) =>
          (lambda (h)

--- a/tests/font-size-test.scm
+++ b/tests/font-size-test.scm
@@ -10,8 +10,8 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(use-modules (convert html tmhtml))
-; (load (string-append (system-getenv "TEXMACS_HOME_PATH") "/plugins/html/progs/convert/html/tmhtml.scm"))
+; (use-modules (convert html tmhtml))
+(load (string-append (system-getenv "TEXMACS_HOME_PATH") "/plugins/html/progs/convert/html/tmhtml.scm"))
 (import (liii check))
 
 ;; Mock environment for testing
@@ -42,6 +42,6 @@
 )
 
 ;; Run all font size tests
-(define (test_font-size-test)
+(tm-define (font-size-test)
   (test-font-size)
   (check-report))

--- a/tests/font-size-test.scm
+++ b/tests/font-size-test.scm
@@ -1,0 +1,47 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : font-size-test.scm
+;; DESCRIPTION : Test suite for tmhtml-with-font-size
+;; COPYRIGHT   : (C) 2024  ATQlove
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-modules (convert html tmhtml))
+; (load (string-append (system-getenv "TEXMACS_HOME_PATH") "/plugins/html/progs/convert/html/tmhtml.scm"))
+(import (liii check))
+
+;; Mock environment for testing
+(define tmhtml-env (make-ahash-table))
+
+;; Mock tmhtml function for testing
+(define (tmhtml arg) arg)
+
+;; Test tmhtml-with-font-size with different font sizes
+(define (test-font-size)
+  ;; Setting a base font size in the environment
+  (ahash-set! tmhtml-env :font-base-size "10")
+
+  ;; Test case 1: target font size is equal to base font size
+  (check 
+    (tmhtml-with-font-size "10" '("This is a test")) 
+    => '((h:span (@ (style "font-size: 100.0%;")) "This is a test")))
+
+  ;; Test case 2: target font size is smaller than base font size
+  (check 
+    (tmhtml-with-font-size "5" '("This is a test")) 
+    => '((h:span (@ (style "font-size: 50.0%;")) "This is a test")))
+
+  ;; Test case 3: target font size is larger than base font size
+  (check 
+    (tmhtml-with-font-size "12" '("This is a test")) 
+    => '((h:span (@ (style "font-size: 120.0%;")) "This is a test")))
+)
+
+;; Run all font size tests
+(define (test_font-size-test)
+  (test-font-size)
+  (check-report))


### PR DESCRIPTION
## What
Fixed font size

## Why
The original code exported html font size analysis is not correct, currently modified can be exported normally. Key modification points:
1. the variable name in the `logic table` failed to correspond, resulting in incorrect recognition of `font-size` variable, change from `font-size` to `font-base-size`;
2. the logic of `tmhtml-with-font-size` function is not perfect. Originally calculate the exported font size according to the relative size, but the calculation process is defective, and the relative size is calculated according to a fixed range, so the difference between the exported fonts is not fine enough. 
3. added some debugging code for later call (now commented and will not be shown).
4. added test code.

## How to test
`/usr/bin/MoganResearch --headless  -b tests\font-size-test.scm -x "(font-size-test)" -q`

tm:
![图片](https://github.com/user-attachments/assets/644b80da-a2e4-4396-ad71-ec5513707994)

html:
![图片](https://github.com/user-attachments/assets/07c48c73-1231-4f92-838a-be74329f45b1)

open in browser:
![图片](https://github.com/user-attachments/assets/15f86044-f29e-4ded-b17d-fc1914d7c7b3)
