### PR TITLE
Set default export to html to use MathML instead of image

### DIFF
--- a/progs/data/html.scm
+++ b/progs/data/html.scm
@@ -65,6 +65,6 @@
   (:function-with-options texmacs->html)
   (:option "texmacs->html:css" "on")
   (:option "texmacs->html:mathjax" "off")
-  (:option "texmacs->html:mathml" "off")
-  (:option "texmacs->html:images" "on")
+  (:option "texmacs->html:mathml" "on")
+  (:option "texmacs->html:images" "off")
   (:option "texmacs->html:css-stylesheet" "---"))

--- a/tests/html/formular.html
+++ b/tests/html/formular.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>No title</title>
+    <meta content="MoganSTEMSuite 1.2.9.1" name="generator" />
+    <meta charset="UTF-8" />
+    <style type="text/css">
+      body { text-align: justify } h5 { display: inline; padding-right: 1em }
+      h6 { display: inline; padding-right: 1em } table { border-collapse:
+      collapse } td { padding: 0.2em; vertical-align: baseline } dt { float:
+      left; min-width: 1.75em; text-align: right; padding-right: 0.75em;
+      font-weight: bold; } dd { margin-left: 2.75em; padding-bottom: 0.25em; }
+      dd p { padding-top: 0em; } .subsup { display: inline; vertical-align:
+      -0.2em } .subsup td { padding: 0px; text-align: left} .fraction {
+      display: inline; vertical-align: -0.8em } .fraction td { padding: 0px;
+      text-align: center } .wide { position: relative; margin-left: -0.4em }
+      .accent { position: relative; margin-left: -0.4em; top: -0.1em }
+      .title-block { width: 100%; text-align: center } .title-block p {
+      margin: 0px } .compact-block p { margin-top: 0px; margin-bottom: 0px }
+      .left-tab { text-align: left } .center-tab { text-align: center }
+      .balloon-anchor { border-bottom: 1px dotted #000000; outline: none;
+      cursor: help; position: relative; } .balloon-anchor [hidden] {
+      margin-left: -999em; position: absolute; display: none; }
+      .balloon-anchor: hover [hidden] { position: absolute; left: 1em; top:
+      2em; z-index: 99; margin-left: 0; width: 500px; display: inline-block; }
+      .balloon-body { } .ornament { border-width: 1px; border-style: solid;
+      border-color: black; display: inline-block; padding: 0.2em; } .right-tab
+      { float: right; position: relative; top: -1em; } .no-breaks {
+      white-space: nowrap; } .underline { text-decoration: underline; }
+      .overline { text-decoration: overline; } .strike-through {
+      text-decoration: line-through; } del { text-decoration: line-through
+      wavy red; } .fill-out { text-decoration: underline dotted; } math {
+      font-family: cmr, times, verdana } 
+    </style>
+  </head>
+  <body>
+    <p>
+      <div style="display: inline">
+        {
+      </div>
+      <table style="display: inline-table; vertical-align: middle">
+        <tbody><tr>
+          <td>x&#x2A7D;3</td>
+        </tr><tr>
+          <td>2*x-y-2&#x2A7E;0</td>
+        </tr><tr>
+          <td>3*x+y-8&#x2A7E;0</td>
+        </tr></tbody>
+      </table>
+      <div style="display: inline">
+        .
+      </div>
+    </p>
+    <p>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"><mstyle scriptlevel="1"><mrow><mo form="prefix">{</mo><mtable
+      columnalign="left">
+        <mtr>
+          <mtd><mrow><mi>x</mi><mo>⩽</mo><mn>3</mn></mrow></mtd>
+        </mtr>
+        <mtr>
+          <mtd><mrow><mn>2</mn><mo>&InvisibleTimes;</mo><mi>x</mi><mo>-</mo><mi>y</mi><mo>-</mo><mn>2</mn><mo>⩾</mo><mn>0</mn></mrow></mtd>
+        </mtr>
+        <mtr>
+          <mtd><mrow><mn>3</mn><mo>&InvisibleTimes;</mo><mi>x</mi><mo>+</mo><mi>y</mi><mo>-</mo><mn>8</mn><mo>⩾</mo><mn>0</mn></mrow></mtd>
+        </mtr>
+      </mtable><mo form="postfix">.</mo></mrow></mstyle></math>
+    </p>
+    <p>
+      
+    </p>
+    <p>
+      y=2*t*sqrt (1-t<sup>2</sup>)
+    </p>
+    <p>
+      <math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mi>y</mi><mo>=</mo><mn>2</mn><mo>&InvisibleTimes;</mo><mi>t</mi><mo>&InvisibleTimes;</mo><msqrt><mrow><mn>1</mn><mo>-</mo><msup><mi>t</mi><mn>2</mn></msup></mrow></msqrt></mrow></math>
+    </p>
+    <p>
+      
+    </p>
+  </body>
+</html>

--- a/tests/tmu/formular.tmu
+++ b/tests/tmu/formular.tmu
@@ -1,0 +1,24 @@
+<TMU|<tuple|1.0.3|1.2.9.1>>
+
+<style|generic>
+
+<\body>
+  <choice|<tformat|<table|<row|<cell|x\<leqslant\>3>>|<row|<cell|2*x-y-2\<geqslant\>0>>|<row|<cell|3*x+y-8\<geqslant\>0>>>>>
+
+  <math|<choice|<tformat|<table|<row|<cell|x\<leqslant\>3>>|<row|<cell|2*x-y-2\<geqslant\>0>>|<row|<cell|3*x+y-8\<geqslant\>0>>>>>>
+
+  \;
+
+  y=2*t*<sqrt|1-t<rsup|2>>
+
+  <math|y=2*t*<sqrt|1-t<rsup|2>>>
+
+  \;
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+    <associate|page-screen-margin|false>
+  </collection>
+</initial>


### PR DESCRIPTION
## What
Set default export to docx to use MathML instead of image

## Why
At present, the function of using MathML for export has been relatively perfect.